### PR TITLE
Allow a clientIdList to be provided to the provider

### DIFF
--- a/API.md
+++ b/API.md
@@ -61,7 +61,7 @@ an AWS account.
 ```typescript
 import { GitHubActionsOidcProvider } from 'cdk-gh-aws-oidc-connect'
 
-new GitHubActionsOidcProvider(scope: Construct, id: string)
+new GitHubActionsOidcProvider(scope: Construct, id: string, props?: GitHubActionsOidcProviderProps)
 ```
 
 ##### `scope`<sup>Required</sup> <a name="cdk-gh-aws-oidc-connect.GitHubActionsOidcProvider.parameter.scope"></a>
@@ -73,6 +73,12 @@ new GitHubActionsOidcProvider(scope: Construct, id: string)
 ##### `id`<sup>Required</sup> <a name="cdk-gh-aws-oidc-connect.GitHubActionsOidcProvider.parameter.id"></a>
 
 - *Type:* `string`
+
+---
+
+##### `props`<sup>Optional</sup> <a name="cdk-gh-aws-oidc-connect.GitHubActionsOidcProvider.parameter.props"></a>
+
+- *Type:* [`cdk-gh-aws-oidc-connect.GitHubActionsOidcProviderProps`](#cdk-gh-aws-oidc-connect.GitHubActionsOidcProviderProps)
 
 ---
 
@@ -241,6 +247,31 @@ public readonly roleName: string;
 - *Default:* generated
 
 The name of the IAM role to create.
+
+---
+
+### GitHubActionsOidcProviderProps <a name="cdk-gh-aws-oidc-connect.GitHubActionsOidcProviderProps"></a>
+
+Props for `GitHubActionsOidcProvider`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { GitHubActionsOidcProviderProps } from 'cdk-gh-aws-oidc-connect'
+
+const gitHubActionsOidcProviderProps: GitHubActionsOidcProviderProps = { ... }
+```
+
+##### `clientIdList`<sup>Optional</sup> <a name="cdk-gh-aws-oidc-connect.GitHubActionsOidcProviderProps.property.clientIdList"></a>
+
+```typescript
+public readonly clientIdList: string[];
+```
+
+- *Type:* `string`[]
+- *Default:* ['sigstore']
+
+The client ID of the GitHub OIDC provider.
 
 ---
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -12,6 +12,19 @@ export interface IGitHubActionsOidcProvider {
 }
 
 /**
+ * Props for `GitHubActionsOidcProvider`.
+ */
+export interface GitHubActionsOidcProviderProps {
+  /**
+   * The client ID of the GitHub OIDC provider.
+   *
+   * @default - ['sigstore']
+   * @stability stable
+   */
+  readonly clientIdList?: string[];
+}
+
+/**
  * Defines an OIDC provider for GitHub workflows.
  *
  * Please note that only a single instance of this provider can be installed in
@@ -45,13 +58,13 @@ export class GitHubActionsOidcProvider extends Construct implements IGitHubActio
    */
   public readonly providerArn: string;
 
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GitHubActionsOidcProviderProps) {
     super(scope, id);
 
     const provider = new iam.CfnOIDCProvider(scope, `${id}.GithubOidcProvider`, {
       url: `https://${GitHubActionsOidcProvider.DOMAIN}`,
       thumbprintList: [GitHubActionsOidcProvider.THUMBPRINT],
-      clientIdList: ['sigstore'],
+      clientIdList: props?.clientIdList || ['sigstore'],
     });
 
     this.providerArn = provider.attrArn;


### PR DESCRIPTION
----

I'm using the official action at https://github.com/aws-actions/configure-aws-credentials and it expects the clientidList to be sts.amazonaws.com

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*